### PR TITLE
Update EA references after org name change [no-ci]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby "2.3.1"
 gem "dotenv-rails", "~> 2.1"
 
 gem "flood_risk_engine",
-    git: "https://github.com/EnvironmentAgency/flood-risk-engine",
+    git: "https://github.com/DEFRA/flood-risk-engine",
     tag: "v1.0.2"
 
 gem "govuk_elements_rails", "~> 1.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/EnvironmentAgency/flood-risk-engine
+  remote: https://github.com/DEFRA/flood-risk-engine
   revision: c2e2f5845de94480e1b2f85010ce6dbc72264c9e
   tag: v1.0.2
   specs:
@@ -74,7 +74,7 @@ GEM
     airbrake (5.3.0)
       airbrake-ruby (~> 1.3)
     airbrake-ruby (1.3.2)
-    arel (6.0.3)
+    arel (6.0.4)
     ast (2.3.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -82,7 +82,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    builder (3.2.2)
+    builder (3.2.3)
     bullet (5.1.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
@@ -108,7 +108,7 @@ GEM
       simplecov (>= 0.7.1, < 1.0.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.3)
+    concurrent-ruby (1.0.4)
     debug_inspector (0.0.2)
     declarative (0.0.8)
       uber (>= 0.0.15)
@@ -123,10 +123,10 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.1.1)
-    dotenv-rails (2.1.1)
-      dotenv (= 2.1.1)
-      railties (>= 4.0, < 5.1)
+    dotenv (2.1.2)
+    dotenv-rails (2.1.2)
+      dotenv (= 2.1.2)
+      railties (>= 3.2, < 5.1)
     ea-address_lookup (0.3.3)
       activesupport (>= 4.2)
       nesty (~> 1.0)
@@ -166,7 +166,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
+    json (1.8.6)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -188,7 +188,7 @@ GEM
       rack
       rake (>= 0.8.1)
     pg (0.18.4)
-    phonelib (0.6.8)
+    phonelib (0.6.9)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -218,9 +218,9 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
+    rails-dom-testing (1.0.8)
       activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Flood Risk Front Office
 
-[![Build Status](https://travis-ci.org/EnvironmentAgency/flood-risk-front-office.svg?branch=develop)](https://travis-ci.org/EnvironmentAgency/flood-risk-front-office)
-[![security](https://hakiri.io/github/EnvironmentAgency/flood-risk-front-office/develop.svg)](https://hakiri.io/github/EnvironmentAgency/flood-risk-front-office/develop)
-[![Code Climate](https://codeclimate.com/github/EnvironmentAgency/flood-risk-front-office/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/flood-risk-front-office)
-[![Test Coverage](https://codeclimate.com/github/EnvironmentAgency/flood-risk-front-office/badges/coverage.svg)](https://codeclimate.com/github/EnvironmentAgency/flood-risk-front-office)
-[![Dependency Status](https://dependencyci.com/github/EnvironmentAgency/flood-risk-engine/badge)](https://dependencyci.com/github/EnvironmentAgency/flood-risk-engine)
+[![Build Status](https://travis-ci.org/DEFRA/flood-risk-front-office.svg?branch=develop)](https://travis-ci.org/DEFRA/flood-risk-front-office)
+[![Code Climate](https://codeclimate.com/github/DEFRA/flood-risk-front-office/badges/gpa.svg)](https://codeclimate.com/github/DEFRA/flood-risk-front-office)
+[![Test Coverage](https://codeclimate.com/github/DEFRA/flood-risk-front-office/badges/coverage.svg)](https://codeclimate.com/github/DEFRA/flood-risk-front-office)
+[![security](https://hakiri.io/github/DEFRA/flood-risk-front-office/develop.svg)](https://hakiri.io/github/DEFRA/flood-risk-front-office/develop)
+[![Dependency Status](https://dependencyci.com/github/DEFRA/flood-risk-engine/badge)](https://dependencyci.com/github/DEFRA/flood-risk-engine)
 
 A Ruby on Rails application delivering the [Flood risk activity exemptions service](https://register-flood-risk-exemption.service.gov.uk).
 
-This is a thin, host application which merely mounts and provides styling for the [flood_risk_engine](https://github.com/EnvironmentAgency/flood-risk-engine) rails engine. The engine is responsible for the service implementation.
+This is a thin, host application which merely mounts and provides styling for the [flood_risk_engine](https://github.com/DEFRA/flood-risk-engine) rails engine. The engine is responsible for the service implementation.
 
 ## Prerequisites
 
@@ -25,7 +25,7 @@ Please make sure the following are installed:
 Clone the repository and install its gem dependencies:
 
 ```bash
-git clone https://github.com/EnvironmentAgency/flood-risk-front-office.git
+git clone https://github.com/DEFRA/flood-risk-front-office.git
 cd flood-risk-front-office
 bundle
 ```
@@ -84,7 +84,7 @@ Then navigate to [http://127.0.0.1:1080](http://127.0.0.1:1080) in your browser.
 
 ## Tests
 
-We use [RSpec](http://rspec.info/) and focus on feature tests in this project that go through the journey for each organisation type (unit testing is done in [flood _risk_engine](https://github.com/EnvironmentAgency/flood-risk-engine) and acceptance tests in [Flood risk acceptance tests](https://github.com/EnvironmentAgency/flood-risk-acceptance-tests)).
+We use [RSpec](http://rspec.info/) and focus on feature tests in this project that go through the journey for each organisation type (unit testing is done in [flood _risk_engine](https://github.com/DEFRA/flood-risk-engine) and acceptance tests in [Flood risk acceptance tests](https://github.com/DEFRA/flood-risk-acceptance-tests)).
 
 To run [Rubocop](https://github.com/bbatsov/rubocop) and the test suite
 
@@ -100,7 +100,7 @@ bundle exec rake spec
 
 ## Quality and conventions
 
-The project is linked to [Travis CI](https://travis-ci.org/EnvironmentAgency/flood-risk-front-office) and all pushes to the **GitHub** are automatically checked.
+The project is linked to [Travis CI](https://travis-ci.org/DEFRA/flood-risk-front-office) and all pushes to the **GitHub** are automatically checked.
 
 The checks include running all tests plus **Rubocop**, but also tools like [HTLMHint](https://github.com/yaniswang/HTMLHint) and [i18n-tasks](https://github.com/glebm/i18n-tasks). Check the `.travis.yml` for full details, specifically the `before_script:` section.
 


### PR DESCRIPTION
The Environment Agency organisation on GitHub recently changed its name to DEFRA. This has resulted in a change to all the urls for all our repos. This changes updates any references to the old repo url's for example

- in repo status badges
- links to other projects in the README
- library links, for example in the `Gemfile`