### PR TITLE
Update parser gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       mini_portile2 (~> 2.1.0)
     os_map_ref (0.4.2)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
     passenger (5.0.30)
       rack
@@ -394,9 +394,8 @@ DEPENDENCIES
   simplecov (~> 0.11.2)
   uglifier (~> 3.0)
 
-
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.16.0
+   1.17.3


### PR DESCRIPTION
When we were setting up the vagrant box for FRAE, we noticed the `bundle install` was breaking. Updating the dependency solves the problem.