### PR TITLE
Re-add whenever gem to fix deployments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "rails", "~> 4.2"
 gem "sass-rails", "~> 5.0.4"
 # Use Uglifier as compressor for JavaScript assets
 gem "uglifier", "~> 3.0"
+# Our capistrano scripts expect whenever (for scheduling cron jobs) to be available
+gem "whenever", "~> 0.9.4", require: false
 
 gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     capybara-email (2.5.0)
       capybara (~> 2.4)
       mail
+    chronic (0.10.2)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
     ci_reporter_rspec (1.0.0)
@@ -354,6 +355,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
     xpath (2.1.0)
       nokogiri (~> 1.3)
 
@@ -390,6 +393,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.4)
   simplecov (~> 0.11.2)
   uglifier (~> 3.0)
+  whenever (~> 0.9.4)
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever


### PR DESCRIPTION
This app does not use whenever for scheduling (although the back office does). However our deployment scripts are built around both apps having the gem installed. So until we are in a position to update our deployment process, we need to reinstall the gem or deployments will be broken.

This undoes the work of a few PRs (#152, #221).