### PR TITLE
Move github changelog generator to main group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,17 @@ gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
     branch: "master"
 
+# Allows us to automatically generate the change log from the tags, issues,
+# labels and pull requests on GitHub. Added as a dependency so all dev's have
+# access to it to generate a log, and so they are using the same version.
+# New dev's should first create GitHub personal app token and add it to their
+# ~/.bash_profile (or equivalent)
+# https://github.com/skywinder/github-changelog-generator#github-token
+# Then simply run `bundle exec rake changelog` to update CHANGELOG.md
+# Should be in the :development group however when it is it breaks deployment.
+# Hence moved outside group till we can understand why.
+gem "github_changelog_generator", require: false
+
 # Automatically loads environment variables from .env into ENV. Specified here
 # rather than in the group in case any of the gems we add depend on env
 # variables being available
@@ -37,14 +48,6 @@ gem "dotenv-rails", "~> 2.1.1", groups: %i[development test]
 group :development do
   # Pretty prints objects in console. Usage `$ ap some_object`
   gem "awesome_print"
-  # Allows us to automatically generate the change log from the tags, issues,
-  # labels and pull requests on GitHub. Added as a dependency so all dev's have
-  # access to it to generate a log, and so they are using the same version.
-  # New dev's should first create GitHub personal app token and add it to their
-  # ~/.bash_profile (or equivalent)
-  # https://github.com/skywinder/github-changelog-generator#github-token
-  # Then simply run `bundle exec rake changelog` to update CHANGELOG.md
-  gem "github_changelog_generator", require: false
   # Used to ensure the code base matches our agreed styles and conventions
   gem "rubocop", "~> 0.47"
 end


### PR DESCRIPTION
The original code for the github changelog generator entry came from [Waste Carriers](https://github.com/DEFRA/waste-carriers-back-office). In the original entry its not in the `development` group but in the main group. A note explains this should be in the `development` group, but due to an error caused by the gem when deploying to heroku, it was moved to the main group.

Well, we're not deploying to heroku anymore so PR #227 added it to the `development` group!

🤦 Well guess what happened when we then deployed this to our environments!?

So it seems the original comment was half right. Though it should be in the development group, putting the entry there breaks any deployment.