### PR TITLE
Alter airbrake config to allow use in development

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,4 @@
 SECRET_KEY_BASE='key_base'
+
+AIRBRAKE_HOST=https://<host>
+AIRBRAKE_PROJECT_KEY=<key>

--- a/config/initializers/02_airbrake.rb
+++ b/config/initializers/02_airbrake.rb
@@ -60,17 +60,7 @@ Airbrake.configure do |c|
     /password/i,
     /postcode/i,
 
-    :name,
-    :address,
-    :address_list,
-    :premises,
-    :street_address,
-    :locality,
-    :city,
-
     :full_name,
-    :position,
-    :org_type,
 
     :name,
     :telephone_number,

--- a/config/initializers/02_airbrake.rb
+++ b/config/initializers/02_airbrake.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Airbrake is an online tool that provides robust exception tracking in your Rails
 # applications. In doing so, it allows you to easily review errors, tie an error
 # to an individual piece of code, and trace the cause back to recent
@@ -9,88 +11,96 @@
 # https://github.com/airbrake/airbrake-ruby#configuration
 require_dependency "airbrake"
 
-if Rails.env.production?
+Airbrake.configure do |c|
 
-  Airbrake.configure do |c|
+  # By default, it is set to airbrake.io As we use our own hosted instance of
+  # Errbit we need to set this value
+  c.host = Rails.application.secrets.airbrake_host
+  # You must set both project_id & project_key. To find your project_id and
+  # project_key navigate to your project's General Settings and copy the values
+  # from the right sidebar.
+  # https://github.com/airbrake/airbrake-ruby#project_id--project_key
+  c.project_id = 1
+  c.project_key = Rails.application.secrets.airbrake_project_key
 
-    # You must set both project_id & project_key. To find your project_id and
-    # project_key navigate to your project's General Settings and copy the values
-    # from the right sidebar.
-    # https://github.com/airbrake/airbrake-ruby#project_id--project_key
-    c.host = Rails.application.secrets.airbrake_host
-    c.project_key = Rails.application.secrets.airbrake_project_key
-    c.project_id = true # Errbit doesn't require a specific project_id, so setting to true
+  # Configures the root directory of your project. Expects a String or a
+  # Pathname, which represents the path to your project. Providing this option
+  # helps us to filter out repetitive data from backtrace frames and link to
+  # GitHub files from our dashboard.
+  # https://github.com/airbrake/airbrake-ruby#root_directory
+  c.root_directory = Rails.root
 
-    # Configures the root directory of your project. Expects a String or a
-    # Pathname, which represents the path to your project. Providing this option
-    # helps us to filter out repetitive data from backtrace frames and link to
-    # GitHub files from our dashboard.
-    # https://github.com/airbrake/airbrake-ruby#root_directory
-    c.root_directory = Rails.root
+  # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
+  # use the Rails' logger.
+  # https://github.com/airbrake/airbrake-ruby#logger
+  c.logger = Rails.logger
 
-    # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
-    # use the Rails' logger.
-    # https://github.com/airbrake/airbrake-ruby#logger
-    c.logger = Rails.logger
+  # Configures the environment the application is running in. Helps the Airbrake
+  # dashboard to distinguish between exceptions occurring in different
+  # environments. By default, it's not set.
+  # NOTE: This option must be set in order to make the 'ignore_environments'
+  # option work.
+  # https://github.com/airbrake/airbrake-ruby#environment
+  c.environment = Rails.env
 
-    # Configures the environment the application is running in. Helps the Airbrake
-    # dashboard to distinguish between exceptions occurring in different
-    # environments. By default, it's not set.
-    # NOTE: This option must be set in order to make the 'ignore_environments'
-    # option work.
-    # https://github.com/airbrake/airbrake-ruby#environment
-    c.environment = Rails.env
+  # Setting this option allows Airbrake to filter exceptions occurring in
+  # unwanted environments such as :test. By default, it is equal to an empty
+  # Array, which means Airbrake Ruby sends exceptions occurring in all
+  # environments.
+  # NOTE: This option *does not* work if you don't set the 'environment' option.
+  # https://github.com/airbrake/airbrake-ruby#ignore_environments
+  c.ignore_environments = %w[test]
 
-    # Setting this option allows Airbrake to filter exceptions occurring in
-    # unwanted environments such as :test. By default, it is equal to an empty
-    # Array, which means Airbrake Ruby sends exceptions occurring in all
-    # environments.
-    # NOTE: This option *does not* work if you don't set the 'environment' option.
-    # https://github.com/airbrake/airbrake-ruby#ignore_environments
-    c.ignore_environments = %w[development test]
+  # A list of parameters that should be filtered out of what is sent to
+  # Airbrake. By default, all "password" attributes will have their contents
+  # replaced.
+  # https://github.com/airbrake/airbrake-ruby#blacklist_keys
+  c.blacklist_keys = [
+    # Catch-all "safety net" regexes.
+    /password/i,
+    /postcode/i,
 
-    # A list of parameters that should be filtered out of what is sent to
-    # Airbrake. By default, all "password" attributes will have their contents
-    # replaced.
-    # https://github.com/airbrake/airbrake-ruby#blacklist_keys
-    c.blacklist_keys = [
-      # Catch-all "safety net" regexes.
-      /password/i,
-      /postcode/i,
+    :name,
+    :address,
+    :address_list,
+    :premises,
+    :street_address,
+    :locality,
+    :city,
 
-      :name,
-      :address,
-      :address_list,
-      :premises,
-      :street_address,
-      :locality,
-      :city,
+    :full_name,
+    :position,
+    :org_type,
 
-      :full_name,
-      :position,
-      :org_type,
+    :name,
+    :telephone_number,
 
-      :name,
-      :telephone_number,
+    :email,
+    :email_address,
+    :email_address_confirmation,
 
-      :email,
-      :email_address,
-      :email_address_confirmation,
+    :reset_password_token,
+    :confirmation_token,
+    :unconfirmed_email,
+    :unlock_token,
 
-      :reset_password_token,
-      :confirmation_token,
-      :unconfirmed_email,
-      :unlock_token,
-
-      # Other things we'll filter beacuse we're super-diligent.
-      :_csrf_token,
-      :session_id,
-      :authenticity_token
-    ]
-  end
-
-  # If Airbrake doesn't send any expected exceptions, we suggest to uncomment the
-  # line below. It might simplify debugging of background Airbrake workers, which
-  # can silently die.
-  # Thread.abort_on_exception = ['test', 'development'].include?(Rails.env)
+    # Other things we'll filter beacuse we're super-diligent.
+    :_csrf_token,
+    :session_id,
+    :authenticity_token
+  ]
 end
+
+# If Airbrake doesn't send any expected exceptions, we suggest to uncomment the
+# line below. It might simplify debugging of background Airbrake workers, which
+# can silently die.
+# Thread.abort_on_exception = ['test', 'development'].include?(Rails.env)
+
+# Unfortunately the airbrake initializer errors if project_key is not set. The
+# problem is that the initializer is fired in scenarios where we are not
+# actually using the app, for example when running a rake task.
+#
+# In production when we run rake tasks it's in an environment where environment
+# variables have not been  set. As such we need a way to disable using airbrake
+# unless we actually need it.
+Airbrake.add_filter(&:ignore!) unless ENV["USE_AIRBRAKE"] == "true"


### PR DESCRIPTION
The previous team took the decision to not activate airbrake in non-production environments, no doubt to reduce noise.

We on the other hand value having it enabled in all environments as it might highlight issues we haven't spotted. It also reduces the differences between the app running in production, and running in other environments.

So for these reasons we're making these changes, which bring the config more inline with our other services, and ensure Airbrake is always enabled by default irrespective of environment.