### PR TITLE
Fix airbrake project env var reference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ ADDRESS_FACADE_KEY='key'
 
 # Airbrake to Errbit error reporting
 AIRBRAKE_HOST = "http://somewhere"
-AIRBRAKE_PROJECT_KEY ="<some key - use anything for dev and test>"
+AIRBRAKE_FO_PROJECT_KEY ="<some key - use anything for dev and test>"
 
 DEVISE_MAILER_SENDER="No reply <no-reply@environment-agency.gov.uk>"
 

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
 SECRET_KEY_BASE='key_base'
 
 AIRBRAKE_HOST=https://<host>
-AIRBRAKE_PROJECT_KEY=<key>
+AIRBRAKE_FO_PROJECT_KEY=<key>

--- a/config/initializers/01_check_for_presence_of_required_env_vars.rb
+++ b/config/initializers/01_check_for_presence_of_required_env_vars.rb
@@ -18,7 +18,7 @@ end
 if Rails.env.production?
   %w(
     AIRBRAKE_HOST
-    AIRBRAKE_PROJECT_KEY
+    AIRBRAKE_FO_PROJECT_KEY
   ).each do |key|
     ENV.fetch(key) { raise "#{key} not found in ENV" }
   end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -3,7 +3,7 @@
 defaults: &defaults
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   airbrake_host: <%= ENV['AIRBRAKE_HOST'] %>
-  airbrake_project_key: <%= ENV['AIRBRAKE_PROJECT_KEY'] || ENV['AIRBRAKE_API_KEY'] %>
+  airbrake_project_key: <%= ENV['AIRBRAKE_FO_PROJECT_KEY'] %>
   pg_host: <%= ENV['PG_HOST'] %>
   pg_port: <%= ENV['PG_PORT'] %>
   pg_database: <%= ENV['PG_DATABASE'] %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-604

At the start of 2019 we migrated the FRAE service to a new environment which had a different struture. Previously the front and back office apps were on separate instances. In the new structure they were put on the same one.

Whilst working on the RUBY-604 we've spotted that both apps refer to just one environment variable; `AIRBRAKE_PROJECT_KEY`. This was fine when they were on separate instances, but now there on one it means all exceptions are being logged to the same project in Errbit.

We like to keep a separate Errbit project for each app as it makes it clearer where an exception has occurred. So this change

- removes the reference to `AIRBRAKE_API_KEY`. It's just not used anywhere anymore
- updates the reference to `AIRBRAKE_FO_PROJECT_KEY`