### PR TITLE
Enable defra-ruby-email in the project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "whenever", "~> 0.9.4", require: false
 
 gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
-    branch: "implement-defra-ruby-email"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "whenever", "~> 0.9.4", require: false
 
 gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
-    branch: "master"
+    branch: "implement-defra-ruby-email"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 29fdf86476437c330ed31552a97d4cc697a163f7
-  branch: master
+  revision: 501a12e62cf6b0bdfc5e50e9fde8ab213af6db25
+  branch: implement-defra-ruby-email
   specs:
     flood_risk_engine (1.0.2)
       activerecord-session_store (~> 1.0)
       defra_ruby_alert (~> 0.1.0)
       defra_ruby_area
+      defra_ruby_email
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
       ea-address_lookup (~> 0.3.0)
@@ -115,6 +116,8 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
+    defra_ruby_email (0.2.0)
+      rails (~> 4.2.11.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     dibber (0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 501a12e62cf6b0bdfc5e50e9fde8ab213af6db25
-  branch: implement-defra-ruby-email
+  revision: 5732407449f9eb3d8ba53b525888ef1f5489626c
+  branch: master
   specs:
     flood_risk_engine (1.0.2)
       activerecord-session_store (~> 1.0)

--- a/config/initializers/flood_risk_engine.rb
+++ b/config/initializers/flood_risk_engine.rb
@@ -3,6 +3,9 @@
 FloodRiskEngine::ApplicationController.layout 'application'
 
 FloodRiskEngine.configure do |config|
+  # Last email cache config
+  config.use_last_email_cache = ENV["USE_LAST_EMAIL_CACHE"] || "false"
+
   # Configure airbrake, which is done via the engine using defra_ruby_alert
   config.airbrake_enabled = ENV["USE_AIRBRAKE"]
   config.airbrake_host = Rails.application.secrets.airbrake_host


### PR DESCRIPTION
Currently the [Waste Exemptions service](https://github.com/DEFRA/waste-exemptions-engine/pull/112) and the [Waste Carriers Frontend](https://github.com/DEFRA/waste-carriers-frontend/pull/227) have the ability to intercept and play back the details of the last email sent.

This feature is only enabled in our non-production environments and is used as part of our acceptance tests. However our QA @andrewhick has rightly pointed out that the functionality is inconsistent across our services.

Waste Exemptions has it throughout, Waste Carriers only has it in the old app, and Flood Risk Activity Exemptions doesn't have it at all. This makes writing and maintaining acceptance tests across the 3 services difficult and inconsistent so we have been asked to resolve the issue.

Rather than duplicate the existing code even more, we have created [defra-ruby-email](https://github.com/DEFRA/defra-ruby-email) a reusable engine that can be mounted into an application to provide the same functionality.

Having created the gem, we implemented it into the [flood-risk-engine](https://github.com/DEFRA/flood-risk-engine/pull/332) to add the feature to this service.

This change completes the implementation for the front-office.