### PR TITLE
Update Postgres image in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:9.6-alpine
+        image: postgres:12.5-alpine
         # Provide the password for postgres
         env:
           POSTGRES_USER: postgres


### PR DESCRIPTION
This is to mirror the version of the DB on other environments.