### PR TITLE
Link to accessibility statement in footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,5 +7,6 @@
   <ul>
     <li class="inline"><%= link_to 'Privacy', page_path('privacy_policy'),  target: "_blank" %></li>
     <li class="inline"><%= link_to 'Cookies', page_path('cookies'),  target: "_blank" %></li>
+    <li class="inline"><%= link_to 'Accessibility', page_path('accessibility'),  target: "_blank" %></li>
   </ul>
 </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1094

This PR links to the accessibility statement we have created based on an accessibility review. The statement itself is located in the flood-risk-engine.

---

Link will be broken until https://github.com/DEFRA/flood-risk-engine/pull/367 is merged in and the host app is updated.