### PR TITLE
PECR Audit - Action 1 - Update cookie banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,13 @@
   <%= csrf_meta_tags %>
 <% end %>
 
+<% content_for(:cookie_message)  do %>
+  <p>
+    <%= t("global_cookies.message") %>
+    <%= link_to t("global_cookies.link_text"), page_path("cookies"), target: "_blank" %>
+  </p>
+<% end %>
+
 <% page_title t(:global_proposition_header) %>
 
 <% content_for :header_class, 'with-proposition' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  global_cookies:
+    message: We only collect essential cookies to help save your information and to keep it secure.
+    link_text: Find out more about cookies
   global_proposition_header: Register a flood risk activity exemption
   layouts:
     application:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1436

- The cookie text is render by the govuk_template (0.17.3) and updated with
`content_for(:cookie_message)`
- The cookie message (currently) is only displayed once.
- To view the cookie text, open an incognito window