### PR TITLE
Cookies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/defra-ruby-template
-  revision: 5e1316d4e1a31e5fc0b3786aea992e47665d2204
+  revision: 7357a79d168411ac6b2eedfa446974e22904586a
   branch: main
   specs:
     defra_ruby_template (3.13.0)

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,0 +1,25 @@
+class CookiesController < ApplicationController
+  def accept_analytics
+    write_cookie_and_redirect(:cookies_policy, :analytics_accepted)
+  end
+
+  def reject_analytics
+    write_cookie_and_redirect(:cookies_policy, :analytics_rejected)
+  end
+
+  def hide_this_message
+    write_cookie_and_redirect(:cookies_preferences_set, true)
+  end
+
+  protected
+
+  def write_cookie_and_redirect(name, value)
+    cookies[name] =
+      {
+        value: value,
+        expires: 1.year
+      }
+
+    redirect_back fallback_location: root_path
+  end
+end

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,25 +1,43 @@
 class CookiesController < ApplicationController
   def accept_analytics
-    write_cookie_and_redirect(:cookies_policy, :analytics_accepted)
+    write_cookie(:cookies_policy, :analytics_accepted)
+    redirect_back fallback_location: root_path
   end
 
   def reject_analytics
-    write_cookie_and_redirect(:cookies_policy, :analytics_rejected)
+    write_cookie(:cookies_policy, :analytics_rejected)
+    redirect_back fallback_location: root_path
   end
 
   def hide_this_message
-    write_cookie_and_redirect(:cookies_preferences_set, true)
+    write_cookie(:cookies_preferences_set, true)
+    redirect_back fallback_location: root_path
+  end
+
+  def update
+    # Google writes the cookies as ".hostname"
+    # so we need to state the domain when removing
+    cookies.to_hash.each_pair do |k, _v|
+      cookies.delete k, domain: ".#{request.hostname}"
+    end
+
+    if params[:analytics] == "accept"
+      write_cookie(:cookies_policy, :analytics_accepted)
+    else
+      write_cookie(:cookies_policy, :analytics_rejected)
+    end
+    write_cookie(:cookies_preferences_set, true)
+
+    redirect_to page_path("cookies", cookies_updated: true)
   end
 
   protected
 
-  def write_cookie_and_redirect(name, value)
+  def write_cookie(name, value)
     cookies[name] =
       {
         value: value,
         expires: 1.year
       }
-
-    redirect_back fallback_location: root_path
   end
 end

--- a/app/views/cookies/_action_confirmed.html.erb
+++ b/app/views/cookies/_action_confirmed.html.erb
@@ -1,0 +1,29 @@
+<div class="govuk-cookie-banner__message govuk-width-container" role="alert">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-cookie-banner__content">
+        <p>
+          <% if cookies[:cookies_policy] == "analytics_accepted" %>
+            <%= t("cookies-banner.accepted.message") %>
+          <% else %>
+            <%= t("cookies-banner.rejected.message") %>
+          <% end %>
+          <%= t(
+            "cookies-banner.link.you_can_at_any_time",
+            link: link_to(
+              t("cookies-banner.link.change_your_cookie_settings"),
+              page_path("cookies"),
+              target: "_blank")
+            ).html_safe
+          %>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-button-group">
+    <%= button_to t("cookies-banner.button.hide_this_message"),
+       hide_this_message_cookies_path,
+       class: "govuk-button"
+    %>
+  </div>
+</div>

--- a/app/views/cookies/_action_confirmed.html.erb
+++ b/app/views/cookies/_action_confirmed.html.erb
@@ -12,8 +12,7 @@
             "cookies-banner.link.you_can_at_any_time",
             link: link_to(
               t("cookies-banner.link.change_your_cookie_settings"),
-              page_path("cookies"),
-              target: "_blank")
+              page_path("cookies"))
             ).html_safe
           %>
         </p>

--- a/app/views/cookies/_action_required.html.erb
+++ b/app/views/cookies/_action_required.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-cookie-banner__message govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+        <%= t('cookies-banner.default.heading') %>
+      </h2>
+      <div class="govuk-cookie-banner__content">
+        <p><%= t('cookies-banner.default.message_1') %></p>
+        <p><%= t('cookies-banner.default.message_2') %></p>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-button-group">
+    <%= button_to t('cookies-banner.button.accept_analytics'),
+        accept_analytics_cookies_path,
+        class: "govuk-button"
+    %>
+    <%= button_to t('cookies-banner.button.reject_analytics'),
+        reject_analytics_cookies_path,
+        class: "govuk-button"
+    %>
+    <%= link_to t('cookies-banner.link.view_cookies'),
+         page_path('cookies'),
+        class: "govuk-link"
+    %>
+  </div>
+</div>

--- a/app/views/cookies/_banner.html.erb
+++ b/app/views/cookies/_banner.html.erb
@@ -1,0 +1,10 @@
+<% unless cookies[:cookies_preferences_set] %>
+  <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="<%= t('cookies-banner.default.heading') %>">
+    <% if cookies[:cookies_policy] %>
+    <%= render partial: "cookies/action_confirmed" %>
+    <% else %>
+    <%= render partial: "cookies/action_required" %>
+    <% end %>
+  </div>
+<% end %>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
 <% content_for :head do %>
   <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>
-  <%= render("shared/google_analytics", google_tag: ENV["GOOGLE_ANALYTICS_ID"]) if ENV["GOOGLE_ANALYTICS_ID"].present? %>
+  <%= render "shared/google_analytics" if ENV["GOOGLE_ANALYTICS_ID"].present? %>
 <% end %>
 
 <% content_for :header_content do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,7 @@
+<% content_for :cookies_banner do %>
+  <%= render partial: "cookies/banner" %>
+<% end %>
+
 <% content_for :head do %>
   <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,28 +1,61 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= page_title t('.heading') %></h1>
+<%= form_tag "/cookies", method: :post do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= page_title t('.heading') %></h1>
+      <p class="govuk-body"><%= t('.text_1') %></p>
+      <p class="govuk-body"><%= t('.text_2') %></p>
 
-    <h3 class="govuk-heading-s"><%= t('.before_you_register') %></h3>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= t('.requirement1') %></li>
-      <li><%= t('.requirement2') %></li>
-    </ul>
+      <h2 class="govuk-heading-m"><%= page_title t('.cookie_settings.subheading') %></h2>
+      <p class="govuk-body"><%= t('.cookie_settings.text_1') %></p>
 
-    <h3 class="govuk-heading-s"><%= t('.we_will') %></h3>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= t('.responsibility1') %></li>
-      <li><%= t('.responsibility2') %></li>
-    </ul>
-
-    <h3 class="govuk-heading-s"><%= t('.you_will_need')%></h3>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= t('.need1') %></li>
-      <li><%= t('.need2') %></li>
-      <li><%= t('.need3') %></li>
-      <li><%= t('.need4') %></li>
-      <li><%= t('.need5') %></li>
-    </ul>
-
-    <%= link_to t('.continue'), flood_risk_engine.new_enrollment_path, class: 'govuk-button', role: 'button' %>
+      <h2 class="govuk-body govuk-!-font-weight-bold"><%= t('.analytics_cookies.subheading') %></h2>
+      <p class="govuk-body"><%= t('.analytics_cookies.text_1') %></p>
+      <p class="govuk-body"><%= t('.analytics_cookies.text_2') %></p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><%= t('.analytics_cookies.list_item_1') %></li>
+        <li><%= t('.analytics_cookies.list_item_2') %></li>
+        <li><%= t('.analytics_cookies.list_item_3') %></li>
+      </ul>
+      <h2 class="govuk-heading-m"><%= page_title t('.essential_cookies.subheading') %></h2>
+      <p class="govuk-body"><%= t('.essential_cookies.text_1') %></p>
+      <p class="govuk-body"><%= t('.essential_cookies.text_2') %></p>
+    </div>
+    <div class="govuk-grid-column-full">
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">
+          <%= t('.cookies_we_use.subheading') %>
+        </caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">
+              <%= t('.cookies_we_use.name') %>
+            </th>
+            <th scope="col" class="govuk-table__header">
+              <%= t('.cookies_we_use.purpose') %>
+            </th>
+            <th scope="col" class="govuk-table__header">
+              <%= t('.cookies_we_use.expires') %>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% %i{ flood_risk_front_office journey_token cookies_policy cookies_preferences_set }.each do |cookie| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%= t(".cookies_we_use.#{cookie}.name") %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= t(".cookies_we_use.#{cookie}.purpose") %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= t(".cookies_we_use.#{cookie}.expires") %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <p class="govuk-body"><%= link_to t('.find_out_more.text'), t('.find_out_more.url') %></p>
+      <%= submit_tag t('.submit_button'), class: "govuk-button" %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,25 +1,62 @@
-<%= form_tag "/cookies", method: :post do %>
+<% if params[:cookies_updated] %>
+  <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        <%= t('.updated.success') %>
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">
+        <%= t('.updated.you_set_your_cookie_preferences') %>
+        <%= link_to t('.updated.go_back_to_the_page_you_were_looking_at'), root_path %>
+      </p>
+    </div>
+  </div>
+<% end %>
+
+<%= form_tag cookies_path, method: :patch do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l"><%= page_title t('.heading') %></h1>
       <p class="govuk-body"><%= t('.text_1') %></p>
       <p class="govuk-body"><%= t('.text_2') %></p>
-
       <h2 class="govuk-heading-m"><%= page_title t('.cookie_settings.subheading') %></h2>
       <p class="govuk-body"><%= t('.cookie_settings.text_1') %></p>
-
-      <h2 class="govuk-body govuk-!-font-weight-bold"><%= t('.analytics_cookies.subheading') %></h2>
-      <p class="govuk-body"><%= t('.analytics_cookies.text_1') %></p>
-      <p class="govuk-body"><%= t('.analytics_cookies.text_2') %></p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><%= t('.analytics_cookies.list_item_1') %></li>
-        <li><%= t('.analytics_cookies.list_item_2') %></li>
-        <li><%= t('.analytics_cookies.list_item_3') %></li>
-      </ul>
-      <h2 class="govuk-heading-m"><%= page_title t('.essential_cookies.subheading') %></h2>
-      <p class="govuk-body"><%= t('.essential_cookies.text_1') %></p>
-      <p class="govuk-body"><%= t('.essential_cookies.text_2') %></p>
+      <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h2 class="govuk-body govuk-!-font-weight-bold"><%= t('.analytics_cookies.subheading') %></h2>
+          <p class="govuk-body"><%= t('.analytics_cookies.text_1') %></p>
+          <p class="govuk-body"><%= t('.analytics_cookies.text_2') %></p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><%= t('.analytics_cookies.list_item_1') %></li>
+            <li><%= t('.analytics_cookies.list_item_2') %></li>
+            <li><%= t('.analytics_cookies.list_item_3') %></li>
+          </ul>
+        </legend>
+        <div class="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= radio_button_tag :analytics, :accept,
+                (cookies[:cookies_policy] && cookies[:cookies_policy] == "analytics_accepted"),
+                class: "govuk-radios__input" %>
+            <%= label_tag :analytics_accept,
+                t('.analytics_cookies.radio_button_label.accept'),
+                class: "govuk-label govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= radio_button_tag :analytics, :reject,
+                !(cookies[:cookies_policy] && cookies[:cookies_policy] == "analytics_accepted"),
+                class: "govuk-radios__input" %>
+            <%= label_tag :analytics_reject,
+                t('.analytics_cookies.radio_button_label.reject'),
+                class: "govuk-label govuk-radios__label" %>
+          </div>
+        </div>
+      </fieldset>
     </div>
+    <h2 class="govuk-heading-m"><%= page_title t('.essential_cookies.subheading') %></h2>
+    <p class="govuk-body"><%= t('.essential_cookies.text_1') %></p>
+    <p class="govuk-body"><%= t('.essential_cookies.text_2') %></p>
     <div class="govuk-grid-column-full">
       <table class="govuk-table">
         <caption class="govuk-table__caption govuk-table__caption--m">

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= page_title t('.heading') %></h1>
+
+    <h3 class="govuk-heading-s"><%= t('.before_you_register') %></h3>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= t('.requirement1') %></li>
+      <li><%= t('.requirement2') %></li>
+    </ul>
+
+    <h3 class="govuk-heading-s"><%= t('.we_will') %></h3>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= t('.responsibility1') %></li>
+      <li><%= t('.responsibility2') %></li>
+    </ul>
+
+    <h3 class="govuk-heading-s"><%= t('.you_will_need')%></h3>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= t('.need1') %></li>
+      <li><%= t('.need2') %></li>
+      <li><%= t('.need3') %></li>
+      <li><%= t('.need4') %></li>
+      <li><%= t('.need5') %></li>
+    </ul>
+
+    <%= link_to t('.continue'), flood_risk_engine.new_enrollment_path, class: 'govuk-button', role: 'button' %>
+  </div>
+</div>

--- a/app/views/shared/_google_analytics.erb
+++ b/app/views/shared/_google_analytics.erb
@@ -1,21 +1,9 @@
+<% if cookies[:cookies_policy] == "analytics_accepted" %>
 <!-- Google Tag Manager -->
-<%
-  # The preferred way to disable analytics for a user is to append
-  # 'ga-disable-' to the GOOGLE_ANALYTICS_ID
-  # https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
-  #
-  # Ideally, this logic would be in the application controller, but we
-  # need to support pages rendered by the flood_risk_engine, so we put it here.
-  google_analytics_id =
-    if cookies[:cookies_policy] == 'analytics_accepted'
-      ENV["GOOGLE_ANALYTICS_ID"]
-    else
-      "ga-disable-#{ ENV["GOOGLE_ANALYTICS_ID"] }"
-    end
-%>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','<%= google_analytics_id %>');</script>
+})(window,document,'script','dataLayer','<%= ENV["GOOGLE_ANALYTICS_ID"] %>');</script>
 <!-- End Google Tag Manager -->
+<% end %>

--- a/app/views/shared/_google_analytics.erb
+++ b/app/views/shared/_google_analytics.erb
@@ -1,10 +1,21 @@
 <!-- Google Tag Manager -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=<%= google_tag %>"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-{'gtm.start': new Date().getTime(),event:'gtm.js'}
-);var f=d.getElementsByTagName(s)[0],
+<%
+  # The preferred way to disable analytics for a user is to append
+  # 'ga-disable-' to the GOOGLE_ANALYTICS_ID
+  # https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+  #
+  # Ideally, this logic would be in the application controller, but we
+  # need to support pages rendered by the flood_risk_engine, so we put it here.
+  google_analytics_id =
+    if cookies[:cookies_policy] == 'analytics_accepted'
+      ENV["GOOGLE_ANALYTICS_ID"]
+    else
+      "ga-disable-#{ ENV["GOOGLE_ANALYTICS_ID"] }"
+    end
+%>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','<%= google_tag %>');</script>
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<%= google_analytics_id %>');</script>
 <!-- End Google Tag Manager -->

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,16 +1,3 @@
-# Be sure to restart your server when you modify this file.
-
-# Add new inflection rules using the following format. Inflections
-# are locale specific, and you may define rules for as many different
-# locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
-
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.irregular 'cookie', 'cookies'
+end

--- a/config/locales/cookies.en.yml
+++ b/config/locales/cookies.en.yml
@@ -47,3 +47,7 @@ en:
         text: Find out more about cookies on GOV.UK
         url: https://www.gov.uk/help/cookie-details
       submit_button: Save and continue
+      updated:
+        success: success
+        you_set_your_cookie_preferences: You’ve set your cookie preferences.
+        go_back_to_the_page_you_were_looking_at: Go back to the page you were looking at.

--- a/config/locales/cookies.en.yml
+++ b/config/locales/cookies.en.yml
@@ -1,0 +1,49 @@
+---
+en:
+  pages:
+    cookies:
+      heading: Cookie settings
+      text_1: Cookies are files saved on your phone, table or computer when you visit a website.
+      text_2: We use cookies to store information about how you use the Register a flood risk activity exemption website.
+      cookie_settings:
+        subheading: Cookie settings
+        text_1: We use 2 types of cookie. You can choose which cookies you're happy for us to use.
+      analytics_cookies:
+        subheading: Cookies that measure website use
+        text_1: We use Google Analytics to measure how you use the website so we can improve it based on user needs. We do not allow Google to use or share the data about how you use this site.
+        text_2: 'Google Analytics sets cookies that store anonymised information about:'
+        list_item_1: how you got to the site
+        list_item_2: the pages you visit on Register a flood risk activity exemption, and how long you spend on each page
+        list_item_3: what you click on while you're visiting the site
+        radio_button_label:
+          accept: Use cookies that measure my website use
+          reject: Do not use cookies that measure my website use
+      essential_cookies:
+        subheading: Strictly necessary cookies
+        text_1: These essential cookies do things like remember your progress through a form.
+        text_2: They will always be on.
+      cookies_we_use:
+        subheading: All the cookies we use
+        name: Name
+        purpose: Purpose
+        expires: Expires
+        flood_risk_front_office:
+          name: flood-risk-front-office
+          purpose: Used for session management and authentication
+          expires: When you close your browser
+        journey_token:
+          name: journey_token
+          purpose: Used for registration management
+          expires: 1 day
+        cookies_policy:
+          name: cookies_policy
+          purpose: Saves your cookie consent settings
+          expires: 1 year
+        cookies_preferences_set:
+          name: cookies_preferences_set
+          purpose: Tells us about your cookie settings
+          expires: 1 year
+      find_out_more:
+        text: Find out more about cookies on GOV.UK
+        url: https://www.gov.uk/help/cookie-details
+      submit_button: Save and continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,23 @@
 ---
 en:
-  global_cookies:
-    message: We only collect essential cookies to help save your information and to keep it secure.
-    link_text: Find out more about cookies
+  cookies-banner:
+    default:
+      heading: Cookies on Register a flood risk activity exemption
+      message_1: We use some essential cookies to make this service work.
+      message_2: We’d also like to use analytics cookies so we can understand how you use the service and make improvements.
+    accepted:
+      message: You’ve accepted analytics cookies.
+    rejected:
+      message: You’ve rejected analytics cookies.
+    button:
+      accept_analytics: Accept analytics cookies
+      reject_analytics: Reject analytics cookies
+      hide_this_message: Hide this message
+    link:
+      view_cookies: View cookies
+      you_can_at_any_time: You can %{link} at any time.
+      change_your_cookie_settings: change your cookie settings
+
   global_proposition_header: Register a flood risk activity exemption
   layouts:
     application:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     get '/state_jumper/:factory/(:state)', :to => 'state_jumper#build_and_display', :as => :build_and_display
   end
 
-  resource :cookies, only: [] do
+  resource :cookies, only: [:post] do
     member do
       post :accept_analytics
       post :reject_analytics

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     get '/state_jumper/:factory/(:state)', :to => 'state_jumper#build_and_display', :as => :build_and_display
   end
 
-  resource :cookies, only: [:post] do
+  resource :cookies, only: [:update] do
     member do
       post :accept_analytics
       post :reject_analytics

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,14 @@ Rails.application.routes.draw do
     get '/state_jumper/:factory/(:state)', :to => 'state_jumper#build_and_display', :as => :build_and_display
   end
 
+  resource :cookies, only: [] do
+    member do
+      post :accept_analytics
+      post :reject_analytics
+      post :hide_this_message
+    end
+  end
+
   # Root currently defined as a static page - see config/initializers/high_voltage.rb
   # If that page is ever moved to the engine, root will need to change to eg
   # root to: "flood_risk_engine/enrollments#new"

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.feature "Cookies", type: :feature do
   let(:cookie_banner_div) { ".govuk-cookie-banner" }
 
+  before { ENV["GOOGLE_ANALYTICS_ID"] = "GA_ID" }
+
   scenario "User accepts analytics cookies" do
     visit "/"
     expect(page).to have_link("View cookies", href: "/pages/cookies")
@@ -16,11 +18,20 @@ RSpec.feature "Cookies", type: :feature do
     end
 
     expect(page).not_to have_css(cookie_banner_div)
+
+    # Note that the google analytics tag is only parsed into a URL
+    # if javascript is enabled.
+    # Here we check that the GOOGLE_ANALYTICS_ID is rendered as expected
+    expect(page.source).to have_text("'script','dataLayer','GA_ID'")
   end
 
   scenario "User rejects analytics cookies" do
     visit "/"
     click_on "Reject analytics cookies"
     expect(page).to have_text("You’ve rejected analytics cookies")
+
+    click_on "Hide this message"
+
+    expect(page.source).to have_text("'script','dataLayer','ga-disable-GA_ID'")
   end
 end

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "Cookies", type: :feature do
+  let(:cookie_banner_div) { ".govuk-cookie-banner" }
+
+  scenario "User accepts analytics cookies" do
+    visit "/"
+    expect(page).to have_link("View cookies", href: "/pages/cookies")
+
+    click_on "Accept analytics cookies"
+    expect(page).to have_text("You’ve accepted analytics cookies")
+
+    within cookie_banner_div do
+      expect(page).to have_link("change your cookie settings", href: "/pages/cookies")
+      click_on "Hide this message"
+    end
+
+    expect(page).not_to have_css(cookie_banner_div)
+  end
+
+  scenario "User rejects analytics cookies" do
+    visit "/"
+    click_on "Reject analytics cookies"
+    expect(page).to have_text("You’ve rejected analytics cookies")
+  end
+end

--- a/spec/features/journey_spec.rb
+++ b/spec/features/journey_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Journey for organisation", type: :feature do
       # Each time the submit button is clicked, we should move to the next
       # step in the work flow.
       work_flow.each do |next_step|
-        find('input[type="submit"]').click
+        within(".govuk-main-wrapper") { find('input[type="submit"]').click }
         expect(current_path).to eql("/enrollments/#{enrollment.token}/steps/#{next_step}")
       end
     end


### PR DESCRIPTION
**Add the updated cookie consent banner**
https://eaflood.atlassian.net/browse/RUBY-1487

This goes beyond the Jira ticket: adding the cookies banner and implementing the behaviour.
The following cookies are set:
- cookies_policy => :analytics_accepted (user clicked 'Accept Analytics')
- cookies_policy => :analytics_rejected (user clicked 'Reject Analytics')
- cookies_preferences_set => true (user clicked 'Hide this message')

All cookies have a 1 year expiration date

**Make cookie consent banner functional**
https://eaflood.atlassian.net/browse/RUBY-1488

This commit toggles the Google Tag Manager state
- If a user has the cookie: cookies_policy => :analytics_accepted,
the google analytics tag is rendered with the GOOGLE_ANALYTICS_ID
- Otherwise the google analytics tag is rendered with 'ga-disable-'
appended to the GOOGLE_ANALYTICS_ID

**Update cookie policy to match Design System standard**
https://eaflood.atlassian.net/browse/RUBY-1489

Based on the [wireframe](https://ofdmnl.axshare.com/cookies.html)

**Allow users to update cookie settings after initial selection**

https://eaflood.atlassian.net/browse/RUBY-1491
Based on Design System [cookies page](https://design-system.service.gov.uk/patterns/cookies-page/)

**Set up Google Analytics Tag Manager to enable/disable Analytics**
https://eaflood.atlassian.net/browse/RUBY-1507

Google analytics cookies are removed when the user changes their cookie policy
from 'accept' to 'reject'