### PR TITLE
Update engine and fix titles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 8654b50fb3668379bdfcced59b0814588a55db26
+  revision: 0cdadf9322b83515dc3a4fa6240e9a2b05e4bfca
   branch: rails6
   specs:
     flood_risk_engine (1.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < FloodRiskEngine::ApplicationController
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  helper FloodRiskEngine::ApplicationHelper
+
   def user_not_authorized(_exception)
     logger.info("Pundit::NotAuthorizedError was raised - attempt to update complete Enrollment")
   end

--- a/app/views/cookies/_action_confirmed.html.erb
+++ b/app/views/cookies/_action_confirmed.html.erb
@@ -12,7 +12,7 @@
             "cookies-banner.link.you_can_at_any_time",
             link: link_to(
               t("cookies-banner.link.change_your_cookie_settings"),
-              page_path("cookies"))
+              main_app.page_path("cookies"))
             ).html_safe
           %>
         </p>
@@ -21,8 +21,8 @@
   </div>
   <div class="govuk-button-group">
     <%= button_to t("cookies-banner.button.hide_this_message"),
-       hide_this_message_cookies_path,
-       class: "govuk-button"
+        main_app.hide_this_message_cookies_path,
+        class: "govuk-button"
     %>
   </div>
 </div>

--- a/app/views/cookies/_action_required.html.erb
+++ b/app/views/cookies/_action_required.html.erb
@@ -12,15 +12,15 @@
   </div>
   <div class="govuk-button-group">
     <%= button_to t('cookies-banner.button.accept_analytics'),
-        accept_analytics_cookies_path,
+        main_app.accept_analytics_cookies_path,
         class: "govuk-button"
     %>
     <%= button_to t('cookies-banner.button.reject_analytics'),
-        reject_analytics_cookies_path,
+        main_app.reject_analytics_cookies_path,
         class: "govuk-button"
     %>
     <%= link_to t('cookies-banner.link.view_cookies'),
-         page_path('cookies'),
+        main_app.page_path('cookies'),
         class: "govuk-link"
     %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
   <%= render "shared/google_analytics" if ENV["GOOGLE_ANALYTICS_ID"].present? %>
 <% end %>
 
+<% content_for :page_title, title %>
+
 <% content_for :header_content do %>
   <%= link_to  t(:global_proposition_header), main_app.root_path, id: "proposition-name", class: "govuk-header__link govuk-header__link--service-name" %>
 <% end %>
@@ -47,13 +49,13 @@
   <h2 class="govuk-visually-hidden">Support links</h2>
   <ul class="govuk-footer__inline-list">
     <li class="govuk-footer__inline-list-item">
-      <%= link_to 'Privacy', page_path('privacy_policy'), class: "govuk-footer__link", target: "_blank" %>
+      <%= link_to 'Privacy', main_app.page_path('privacy_policy'), class: "govuk-footer__link", target: "_blank" %>
     </li>
     <li class="govuk-footer__inline-list-item">
-      <%= link_to 'Cookies', page_path('cookies'), class: "govuk-footer__link", target: "_blank" %>
+      <%= link_to 'Cookies', main_app.page_path('cookies'), class: "govuk-footer__link", target: "_blank" %>
     </li>
     <li class="govuk-footer__inline-list-item">
-      <%= link_to 'Accessibility', page_path('accessibility'), class: "govuk-footer__link", target: "_blank" %>
+      <%= link_to 'Accessibility', main_app.page_path('accessibility'), class: "govuk-footer__link", target: "_blank" %>
     </li>
   </ul>
 <% end %>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -17,10 +17,10 @@
 <%= form_tag cookies_path, method: :patch do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l"><%= page_title t('.heading') %></h1>
+      <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
       <p class="govuk-body"><%= t('.text_1') %></p>
       <p class="govuk-body"><%= t('.text_2') %></p>
-      <h2 class="govuk-heading-m"><%= page_title t('.cookie_settings.subheading') %></h2>
+      <h2 class="govuk-heading-m"><%= t('.cookie_settings.subheading') %></h2>
       <p class="govuk-body"><%= t('.cookie_settings.text_1') %></p>
       <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
@@ -54,7 +54,7 @@
         </div>
       </fieldset>
     </div>
-    <h3 class="govuk-heading-s"><%= page_title t('.essential_cookies.subheading') %></h2>
+    <h3 class="govuk-heading-s"><%= t('.essential_cookies.subheading') %></h2>
     <p class="govuk-body"><%= t('.essential_cookies.text_1') %></p>
     <p class="govuk-body"><%= t('.essential_cookies.text_2') %></p>
 

--- a/spec/features/new_registration_spec.rb
+++ b/spec/features/new_registration_spec.rb
@@ -4,6 +4,6 @@ RSpec.feature "New scenario" do
   scenario "in general" do
     visit main_app.root_path
 
-    expect(page).to have_css("h3", text: "Before you register you must")
+    expect(page).to have_css("h2", text: "Before you register you must")
   end
 end


### PR DESCRIPTION
This engine update includes a large number of small fixes to the journey. It also changes how titles are set in the ApplicationHelper and requires host app paths that are loaded on engine pages to use the `main_app.whatever_path` convention.