### PR TITLE
Update engine and configure default assistance mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: e40d6a198f068218b5b7fc71252f3ba0d28e5c5e
+  revision: 50bbebd638c3a4c37656715f6c6931a26c314961
   branch: rails6
   specs:
     flood_risk_engine (1.1)
@@ -20,7 +20,6 @@ GIT
       defra_ruby_validators
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
-      has_secure_token (~> 1.0.0)
       high_voltage (~> 3.0)
       nokogiri (>= 1.11)
       os_map_ref (= 0.4.2)
@@ -219,8 +218,6 @@ GEM
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
-    has_secure_token (1.0.0)
-      activerecord (>= 3.0)
     high_voltage (3.1.2)
     http-accept (1.7.0)
     http-cookie (1.0.4)

--- a/config/initializers/flood_risk_engine.rb
+++ b/config/initializers/flood_risk_engine.rb
@@ -35,6 +35,8 @@ FloodRiskEngine.configure do |config|
     :authenticity_token
   ]
 
+  config.default_assistance_mode = 0
+
   config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
 end
 FloodRiskEngine.start_airbrake


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1604

This configures the front office to set the assistance mode of any registrations submitted here as 'unassisted'.