### PR TITLE
[1910] adds missing libraries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ gem "defra_ruby_template",
 gem "govuk_design_system_formbuilder"
 gem "high_voltage"
 gem "jquery-rails", "~> 4.4"
-gem "net-smtp"
+gem "net-imap", require: false
+gem "net-pop", require: false
+gem "net-smtp", require: false
 gem "pg"
 gem "pundit"
 gem "rails", "~> 6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,14 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     multi_json (1.15.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -385,6 +393,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.3)
     sucker_punch (2.0.4)
       concurrent-ruby (~> 1.0.0)
     thor (1.2.1)
@@ -432,6 +441,8 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   high_voltage
   jquery-rails (~> 4.4)
+  net-imap
+  net-pop
   net-smtp
   passenger (~> 6.0)
   pg


### PR DESCRIPTION
Deploys to dev are failing, this aims to remedy this by including gems/libraries no longer included in ruby 3.1

https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp/70500221#70500221