### PR TITLE
RUBY-2480: moving dependency loading from engine to an app

### DIFF
--- a/config/initializers/flood_risk_engine.rb
+++ b/config/initializers/flood_risk_engine.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# these classses are required on boot, so have to be loaded explicitly (since Rails 7 - zeitwerk autoloader)
+require "flood_risk_engine/email_helper"
+require "flood_risk_engine/application_controller"
+
 FloodRiskEngine::ApplicationController.layout 'application'
 
 FloodRiskEngine.configure do |config|


### PR DESCRIPTION
moving dependency loading from engine to an app