### PR TITLE
[RUBY-3225] Update `defra_ruby_template` gem and improve cookie banner styling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
 source "https://rubygems.org"
 ruby "3.2.2"
 
-gem "defra_ruby_template",
-    git: "https://github.com/DEFRA/defra-ruby-template",
-    branch: "main"
+gem "defra_ruby_template", "~> 5.0"
 gem "faraday"
 gem "faraday-retry"
 gem "govuk_design_system_formbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/DEFRA/defra-ruby-template
-  revision: aea06c6c2b4a6bebe61b735f1b2d6ef70e6a1569
-  branch: main
-  specs:
-    defra_ruby_template (5.4.1)
-
-GIT
   remote: https://github.com/DEFRA/flood-risk-engine
   revision: ab9fbfd68a57e533cfb37f7bf33e8af04be49947
   branch: main
@@ -205,6 +198,7 @@ GEM
       rubocop-factory_bot
       rubocop-rake
       rubocop-rspec
+    defra_ruby_template (5.4.1)
     defra_ruby_validators (2.6.0)
       activemodel
       i18n
@@ -312,6 +306,8 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.3)
+    nokogiri (1.16.7-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
@@ -514,6 +510,7 @@ GEM
     zeitwerk (2.6.17)
 
 PLATFORMS
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -524,7 +521,7 @@ DEPENDENCIES
   capybara-email
   ci_reporter_rspec
   defra_ruby_style
-  defra_ruby_template!
+  defra_ruby_template (~> 5.0)
   defra_ruby_validators
   dotenv-rails
   factory_bot_rails

--- a/app/views/cookies/_action_confirmed.html.erb
+++ b/app/views/cookies/_action_confirmed.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-cookie-banner__content">
-        <p>
+        <p class="govuk-body">
           <% if cookies[:cookies_policy] == "analytics_accepted" %>
             <%= t("cookies-banner.accepted.message") %>
           <% else %>
@@ -12,7 +12,9 @@
             "cookies-banner.link.you_can_at_any_time",
             link: link_to(
               t("cookies-banner.link.change_your_cookie_settings"),
-              "/cookies/edit")
+              "/cookies/edit",
+              class: "govuk-link"
+            )
             ).html_safe
           %>
         </p>

--- a/app/views/cookies/_action_required.html.erb
+++ b/app/views/cookies/_action_required.html.erb
@@ -5,8 +5,8 @@
         <%= t('cookies-banner.default.heading') %>
       </h2>
       <div class="govuk-cookie-banner__content">
-        <p><%= t('cookies-banner.default.message_1') %></p>
-        <p><%= t('cookies-banner.default.message_2') %></p>
+        <p class="govuk-body"><%= t('cookies-banner.default.message_1') %></p>
+        <p class="govuk-body"><%= t('cookies-banner.default.message_2') %></p>
       </div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 <% content_for :page_title, title %>
 
 <% content_for :header_content do %>
-  <%= link_to  t(:global_proposition_header), main_app.root_path, id: "proposition-name", class: "govuk-header__link govuk-header__link--service-name" %>
+  <%= link_to  t(:global_proposition_header), main_app.root_path, id: "proposition-name", class: "govuk-header__link govuk-header__service-name" %>
 <% end %>
 
 <% content_for :phase_banner do %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3225

- Changed `defra_ruby_template` gem source to version `~> 5.0` in `Gemfile` and `Gemfile.lock`
- Added `govuk-body` class to paragraphs in cookie banners for consistent styling
- Updated `govuk-link` class for cookie settings link
- Fixed incorrect class in application layout header link
