### PR TITLE
Upgrade to Rails 7.2.2.1 and update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "whenever"
 
 gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
-    branch: "rails-7.2.2.1-upgrade"
+    branch: "main"
 
 # This is specified in the engine gemspec,
 # but need to specify here also to pick up i18n locales

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: dc7768bf26a3c91ada23aafcd68ba13f04f3f59f
-  branch: rails-7.2.2.1-upgrade
+  revision: 103d053bcfc0cd732449dce8ffca8a927669eff2
+  branch: main
   specs:
     flood_risk_engine (1.2)
       aasm (~> 5.5)


### PR DESCRIPTION
- Upgraded Rails and related gems to version 7.2.2.1
- Updated activerecord-postgis-adapter to 10.0.1 and rgeo-activerecord to 8.0.0
- Updated various gems to latest compatible versions
- Added config/secrets path handling from frae back-office
